### PR TITLE
ci: migrate soldeer publishing to rainix-autopublish

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -1,0 +1,11 @@
+name: Package Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
+    with:
+      soldeer-package: rain-datacontract
+    secrets: inherit

--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -1,9 +1,0 @@
-name: Publish to Soldeer
-on:
-  push:
-    tags:
-      - "v*"
-jobs:
-  publish:
-    uses: rainlanguage/rainix/.github/workflows/publish-soldeer.yaml@main
-    secrets: inherit

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,7 @@
+[package]
+name = "rain-datacontract"
+version = "0.1.0"
+
 [profile.default]
 libs = ["dependencies"]
 


### PR DESCRIPTION
Part of removing the manual `publish-soldeer` reusable from rainix. Adds `[package].version = 0.1.0` (current registry release) to foundry.toml, replaces the tag-driven wrapper with `rainix-autopublish` (`soldeer-package: rain-datacontract`). Release model: tag → bump version + merge to main. No publish fires from this PR.